### PR TITLE
Use a fake API key on Travis

### DIFF
--- a/tests/testthat/helper-microdemic.R
+++ b/tests/testthat/helper-microdemic.R
@@ -1,5 +1,10 @@
 # set up vcr
 library("vcr")
+
+# set fake API key on Travis so check_key() doesn't throw an error
+if (identical(Sys.getenv("TRAVIS"), "true")) {
+  Sys.setenv("MICROSOFT_ACADEMIC_KEY" = "fake_key")
+}
 invisible(vcr::vcr_configure(
     dir = "../fixtures",
     filter_sensitive_data = list("<<<microdemic_api_key>>>" = Sys.getenv('MICROSOFT_ACADEMIC_KEY'))


### PR DESCRIPTION
This removes the requirement that MICROSOFT_ACADEMIC_KEY be set by users in their Travis settings.

See #10 for conversation re: this PR.