### PR TITLE
Pass detailed error message along to user if possible (closes #7)

### DIFF
--- a/tests/fixtures/ma_error.yml
+++ b/tests/fixtures/ma_error.yml
@@ -1,0 +1,30 @@
+http_interactions:
+- request:
+    method: get
+    uri: https://api.labs.cognitive.microsoft.com/academic/v1.0/evaluate?expr=hi-there&count=10&offset=0&attributes=Id%2CAA.AuN%2CJ.JN%2CTi%2CY%2CE%2CCC&model=latest
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      User-Agent: libcurl/7.54.0 r-curl/3.2 crul/0.6.0
+      Accept-Encoding: gzip, deflate
+      Accept: application/json, text/xml, application/xml, */*
+      Ocp-Apim-Subscription-Key: <<<microdemic_api_key>>>
+  response:
+    status:
+      status_code: '400'
+      message: Bad Request
+      explanation: Bad request syntax or unsupported method
+    headers:
+      status: HTTP/1.1 400 Bad Request
+      content-length: '100'
+      content-type: application/json
+      access-control-allow-origin: '*'
+      request-context: appId=cid-v1:7cd06f0e-6d73-46a5-9c10-4ebe681d0156
+      x-powered-by: ASP.NET
+      date: Sat, 12 Jan 2019 03:18:16 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: eyJFcnJvciI6eyJDb2RlIjoiQmFkIEFyZ3VtZW50IiwiTWVzc2FnZSI6IkludmFsaWQgcXVlcnkgZXhwcmVzc2lvblxyXG5QYXJhbWV0ZXIgbmFtZTogZXhwcmVzc2lvbiJ9fQ==
+  recorded_at: 2019-01-12 03:18:16 GMT
+  recorded_with: vcr/0.1.0, webmockr/0.2.6, crul/0.6.0

--- a/tests/testthat/test-error-msgs.R
+++ b/tests/testthat/test-error-msgs.R
@@ -1,0 +1,12 @@
+context("ma_error")
+
+test_that("Detailed error messages are provided when possible", {
+  skip_on_cran()
+
+  vcr::use_cassette("ma_error", {
+    expect_error(
+      ma_search(query = "hi-there"),
+      "query"
+    )
+  }, preserve_exact_body_bytes = TRUE)
+})


### PR DESCRIPTION
This PR attempts to parse the error message contained in the body of the API's response. If the message can be parsed, it's passed along to the user in a detailed error message. Otherwise, a generic error message corresponding to the HTTP status code is provided. Closes #7.

### Examples

This is what error messages look like in the current version of `microdemic` (note, I have `fauxpas` installed, so `raise_for_status()` is calling `fauxpas::http()` for error handling - https://github.com/ropensci/crul/blob/dba96adc1685aa237b9465074adcf2e00f675ac5/R/response.R#L149-L154).

``` r
library(microdemic)

ma_evaluate(
  query = "bad-query",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
)
#> Error: Bad Request (HTTP 400)

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
  offset = "bad-offset"
)
#> Error: Bad Request (HTTP 400)

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = "bad_key"
)
#> Error: Unauthorized (HTTP 401)
```

Examples of error messages when using version of `microdemic` found in this PR:

``` r
library(microdemic)

# The detailed error message provided by the API is literally "Invalid query 
# expression\r\nParameter name: expression"
ma_evaluate(
  query = "bad-query",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
)
#> Error: 400 (HTTP Bad Argument)
#> Explanation: Invalid query expression
#> Parameter name: expression

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
  offset = "bad-offset"
)
#> Error: 400 (HTTP Bad Argument)
#> Explanation: offset should be an integer

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = "bad_key"
)
#> Error: 401 (HTTP Unspecified)
#> Explanation: Access denied due to invalid subscription key. Make sure you are subscribed to an API you are trying to call and provide the right key.
```

Examples of error messages if parsing of error message fails in `parse_error_msg()`. This is also what error messages look like in the current version of `microdemic` if the user doesn't have `fauxpas` installed.

``` r
library(microdemic)

ma_evaluate(
  query = "bad-query",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
)
#> Error: 400 (HTTP Bad Request)
#> Explanation: Bad request syntax or unsupported method

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = Sys.getenv("MICROSOFT_ACADEMIC_KEY"),
  offset = "bad-offset"
)
#> Error: 400 (HTTP Bad Request
#> Explanation: Bad request syntax or unsupported method

ma_evaluate(
  query = "Y=[2010, 2012)",
  key = "bad_key"
)
#> Error: 401 (HTTP Unauthorized)
#> Explanation: No permission -- see authorization schemes
```